### PR TITLE
SOW-25: fix broken link in news story

### DIFF
--- a/app/views/government/news/30-month-process-to-launch-for-local-plan-creation.html
+++ b/app/views/government/news/30-month-process-to-launch-for-local-plan-creation.html
@@ -203,7 +203,9 @@ for creating local plans - News story" %} {% block content %}
 
                       <p>
                         You can read a summary of the new timeline in the
-                        <a href="" class="govuk-link"
+                        <a
+                          href="/guidance/30-month-process-explained"
+                          class="govuk-link"
                           >30-month process explained</a
                         >.
                       </p>


### PR DESCRIPTION
Link now points to the guidance page